### PR TITLE
Fix Ctrl-O subshell toggle and F3 closing the viewer

### DIFF
--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -112,7 +112,7 @@ A quick **Alt** + digit does the same.
 - `F8` — (Markdown files) toggle Raw / Render
 - `n` — Repeat the last search
 - `↑ ↓` / `PgUp PgDn` / `Home End` — Scroll
-- `Esc` / `F10` / `q` — Close
+- `F3` / `Esc` / `F10` / `q` — Close (F3 toggles the viewer, as in the panels)
 
 ### Editor (F4)
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -59,9 +59,8 @@ pub async fn run(startup: crate::Startup) -> Result<()> {
     // screen, before the event stream starts consuming stdin (the probe reads
     // the terminal's query responses directly).
     state.gfx = crate::ui::graphics::Gfx::detect(&state.config.graphics);
-    let mut events = EventStream::new();
 
-    let result = run_loop(&mut term, &mut state, &mut rx, &mut events).await;
+    let result = run_loop(&mut term, &mut state, &mut rx).await;
 
     // Remember each panel's view format and sort order for the next session.
     state.persist_panel_views();
@@ -73,7 +72,6 @@ async fn run_loop(
     term: &mut Term,
     state: &mut AppState,
     rx: &mut AppReceiver,
-    events: &mut EventStream,
 ) -> Result<()> {
     // ~100 ms tick drives animations and the system-status sampler.
     let mut ticker = tokio::time::interval(std::time::Duration::from_millis(100));
@@ -81,6 +79,11 @@ async fn run_loop(
 
     // Persistent Ctrl-O subshell, kept alive across toggles.
     let mut subshell: Option<crate::shell::Subshell> = None;
+    // The crossterm event stream is owned here (not by `run`) so the Ctrl-O
+    // subshell path can drop it: its background reader thread would otherwise
+    // keep competing for stdin while the subshell does its own blocking read,
+    // stealing the very Ctrl-O that should toggle back.
+    let mut events = EventStream::new();
 
     loop {
         // Start-in-editor mode (`rc /edit …`): once the editor and any of its
@@ -116,7 +119,16 @@ async fn run_loop(
                                 Flow::RunExternal { program, path } => {
                                     run_external(term, state, &program, &path).await?
                                 }
-                                Flow::SubShell => toggle_subshell(term, state, &mut subshell).await?,
+                                Flow::SubShell => {
+                                    // Release the event stream's stdin reader
+                                    // so the subshell owns the terminal input
+                                    // while toggled in (its Ctrl-O to return
+                                    // would otherwise be swallowed by the reader
+                                    // thread). A fresh stream is recreated after.
+                                    drop(events);
+                                    toggle_subshell(term, state, &mut subshell).await?;
+                                    events = EventStream::new();
+                                }
                                 Flow::Continue => {}
                             }
                         }
@@ -128,7 +140,11 @@ async fn run_loop(
                             Flow::RunExternal { program, path } => {
                                 run_external(term, state, &program, &path).await?
                             }
-                            Flow::SubShell => toggle_subshell(term, state, &mut subshell).await?,
+                            Flow::SubShell => {
+                                drop(events);
+                                toggle_subshell(term, state, &mut subshell).await?;
+                                events = EventStream::new();
+                            }
                             Flow::Continue => {}
                         }
                     }

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -359,7 +359,11 @@ impl ViewerState {
         }
 
         match key.code {
-            KeyCode::F(10) | KeyCode::Esc | KeyCode::Char('q') => return ViewerSignal::Close,
+            // F3 toggles the viewer (open in the panels, close here), matching
+            // the footer's "Quit" label; F10 / Esc / q also close.
+            KeyCode::F(3) | KeyCode::F(10) | KeyCode::Esc | KeyCode::Char('q') => {
+                return ViewerSignal::Close
+            }
             KeyCode::F(2) => self.wrap = !self.wrap,
             KeyCode::F(4) => {
                 self.mode = match self.mode {
@@ -911,6 +915,25 @@ mod tests {
         // F10 (Quit) spans cols 36-39 → closes.
         let sig = v.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 36, 12));
         assert!(matches!(sig, ViewerSignal::Close), "clicking F10 quits");
+    }
+
+    #[test]
+    fn f3_closes_the_viewer() {
+        // F3 opens the viewer from the panels, so it must also close it (the
+        // footer labels F3 as "Quit"); F10 and Esc remain close keys too.
+        let mut v = ViewerState::new("t".into(), many_lines(10));
+        with_layout(&mut v);
+        let press = |code: KeyCode| KeyEvent::new(code, KeyModifiers::NONE);
+        assert!(
+            matches!(v.handle_key(press(KeyCode::F(3))), ViewerSignal::Close),
+            "F3 closes the viewer"
+        );
+        let mut v = ViewerState::new("t".into(), many_lines(10));
+        with_layout(&mut v);
+        assert!(
+            matches!(v.handle_key(press(KeyCode::F(10))), ViewerSignal::Close),
+            "F10 still closes the viewer"
+        );
     }
 
     /// `n` lines of exactly 5 bytes each ("aaaa\n"), so byte offsets are tidy.


### PR DESCRIPTION
Two unrelated bug fixes, on a fresh branch off main.

## 1. Ctrl-O subshell no longer toggles back (stdin race)

**Symptom:** pressing Ctrl-O drops into the shell, but it looks like the whole app went to the background (patchy shell input), and pressing Ctrl-O again does nothing — the app never comes back.

**Root cause:** crossterm's EventStream keeps a background thread blocking on stdin. run_until_toggle (in shell.rs) does its own blocking stdin read to forward bytes to the shell PTY and watch for the Ctrl-O byte (0x0F). The two readers race for the same fd: the shell receives partial input, and the second Ctrl-O is consumed by the event-stream thread — so the toggle never fires.

**Fix:** own the EventStream in run_loop (instead of borrowing it from run) and drop it before entering the subshell. Its Drop wakes and releases the reader thread via the waker pipe, giving the subshell exclusive access to stdin. A fresh EventStream is recreated once the subshell returns. The same drop/recreate is applied to the (theoretical) mouse SubShell path for consistency.

This matches crossterm 0.29's EventStream Drop, which sets the shutdown flag and wakes poll_internal so the reader returns without consuming stdin.

## 2. F3 does not exit the viewer

**Symptom:** pressing F3 inside the viewer does nothing.

**Root cause:** ViewerState::handle_key closed the viewer on F10 / Esc / q, but not on F3 — even though the footer bar labels F3 as "Quit", and clicking that F3 segment (activate_fkey index 2) already closed it. The keyboard path was simply missing, so the open/close toggle was inconsistent (the panels open the viewer with F3, but F3 wouldn't close it).

**Fix:** add KeyCode::F(3) to the close path, so F3 toggles the viewer as in Midnight Commander. Updated the manual accordingly.

## Verification
- cargo build clean; cargo clippy adds no new warnings.
- cargo test → 372 passed / 0 failed.
- New test f3_closes_the_viewer covers the keyboard F3 (and F10) close path; the existing fkey_bar_click_runs_the_function already covers the click path.

The Ctrl-O fix isn't unit-testable (it needs a real PTY + interactive stdin); the change is structural and the reasoning is documented inline.
